### PR TITLE
Rewrite of purge-old-kernels

### DIFF
--- a/purge-old-kernels
+++ b/purge-old-kernels
@@ -126,7 +126,7 @@ Pkgs="$(dpkg-query -W -f='${Status} ${Package}\n' "linux-*" |
  awk '$2!="ok" || ($3!="installed" && $3!="not-installed") {print $4}')"
 if [ "${Pkgs}" ]; then
  echo -e "WARNING: The following linux packages are not properly\
- installed. You may want to purge or reinstall them manually:\n"${Pkgs} >&2
+ installed or purged. You may want to purge or reinstall them manually:\n"${Pkgs} >&2
  if ! [ "$yes" ]; then
   read -r -p "Continue anyway (y/n)? " response
   response=${response,,}    # tolower
@@ -165,9 +165,9 @@ if [ "${Versions}" ]; then
     # List versions of kernels that have reserve dependencies
 
     LatestVersions="$(dpkg-query -W -f='${Package} ${Status}\n' |
-    awk '/^linux-(.+-|)image-[^0-9]+(-lts-[^ ]+|) (install|hold) ok installed/{print $1}' |
-    xargs dpkg-query -W -f='${Depends}\n' |
-    sed -nr "s/\<linux-(.+-|)image-([0-9.]+-[^-]+)-.*/\2/p" | sort -uV)"
+	awk '/^linux-(.+-)?image-[^0-9]+(-lts-[^ ]+)? (install|hold) ok installed/{print $1}' |
+	xargs dpkg-query -W -f='${Depends}\n' |
+	sed -nr "s/\<linux-(.+-)?image-([0-9.]+-[^-]+)-.*/\2/p" | sort -uV)"
 
     # Get the older versions to remove; never remove latest kernels though.
     CandidateVersionsToPurge="$(comm -23 <(head -n ${num} <<<"${Versions}") \

--- a/purge-old-kernels
+++ b/purge-old-kernels
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright (C) 2015       Jarno Suni (8@iki.fi)
+#  Copyright (C) 2015, 2016       Jarno Suni (8@iki.fi)
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -33,9 +33,13 @@ Options:
     -h, -?, --help  Display this help and exit.
     -k NUM,
     --keep NUM,
-    --keep=NUM	    Keep NUM kernels that are older than the currently
-                    used one. Default is 1.
-    -s, --simulate  Dry-run; don't actually remove packages. You do not
+    --keep=NUM      Keep NUM kernels that are older than the currently
+                    used one. Default is 1. More older kernels may be
+                    kept, if they have such reverse dependencies
+                    installed that are required for getting kernel
+                    updates, or if there are more than one type of
+                    kernels installed with same version number.
+    -s, --simulate  Dry-run; do not actually remove packages. You do not
                     have to be superuser with this option.
     -y, --yes       Purge without user confirmation.
 
@@ -62,7 +66,7 @@ while :; do
             exit
             ;;
         -k|--keep)
-			if ! ${2:+false}; then
+            if ! ${2:+false}; then
               n=$2
               shift 2
               continue
@@ -76,12 +80,12 @@ while :; do
         --keep=)
              error 'Must specify a non-empty "--keep NUM" argument.'
             ;;
-		-s|--simulate)
-			simulate="-s"
-			;;
+        -s|--simulate)
+            simulate="-s"
+            ;;
         -y|--yes)
-			yes="-y"
-			;;
+            yes="-y"
+            ;;
         --)              # End of all options.
             shift
             break
@@ -131,15 +135,22 @@ sort --version-sort --unique)"
 # current kernel version number (present in the respective kernel
 # package name, too)
 current="$(uname -r | cut -f1,2 -d-)"
+# List versions of kernels that have reserve dependencies
+LatestVersions="$(dpkg-query -W -f='${Package} ${Status}\n' |
+ awk '/^linux-image-(generic|lowlatency|virtual)(-lts-[^ ]+|) install ok installed/{print $1}' |
+ xargs dpkg-query -W -f='${Depends}\n' |
+ sed -nr "s/.*linux-image-([[:digit:].]+-[^-]+)-.*/\1/p" | sort -uV)"
 
 # keep n versions that are older than the current one (if they exist).
 num=$(awk '($0==c){a=NR-1-n; if(a>0){print a}else{print 0} exit}' c=${current} n=$n <<<"${Versions}")
-VersionsToPurge="$(head -n ${num} <<<"${Versions}")"
+
+# Get the older versions to remove; never remove latest kernels though.
+VersionsToPurge="$(comm -23 <(head -n ${num} <<<"${Versions}") <(echo -e "${LatestVersions}"))"
 
 if [ "${VersionsToPurge}" ]; then
-	# purge linux packages matching the versions
-	apt-get -q ${simulate} ${yes} purge $(
+    # purge linux packages matching the versions
+    apt-get -q ${simulate} ${yes} purge --auto-remove $(
     sed -r -e 's/\./\\./g' -e 's/.*/^linux-.+-&($|-)/' <<<"$VersionsToPurge")
 else
-	echo "0 kernels purged."
+    echo "0 kernels purged."
 fi

--- a/purge-old-kernels
+++ b/purge-old-kernels
@@ -45,7 +45,7 @@ Options:
                     updates. Also, if a key linux-image package is
                     marked "hold" by e.g. apt-mark, kernels with the
                     respective version are not removed.
-    -s, --simulate  Dry-run; don't actually remove packages. You do not
+    -s, --simulate  Dry-run; do not actually remove packages. You do not
                     have to be superuser with this option.
     -y, --yes       Purge without user confirmation.
 

--- a/purge-old-kernels
+++ b/purge-old-kernels
@@ -19,6 +19,7 @@
 
 set -o nounset
 set -o errexit
+#set -o xtrace
 
 # Usage info
 show_help() {
@@ -26,8 +27,12 @@ cat << EOF
 Usage: ${0##*/} [OPTION]...
 Purge some kernel related packages that have older version than the
 current kernel. This is especially useful in order to prevent /boot
-partition from getting full. First warn, if some linux-* packages are
-only partially or unsuccessfully installed.
+partition from getting full. Also purge the kernel packages of certain
+version, if the installed key linux-image packages are marked for
+removal by dpkg --set-selections.
+
+First warn, if some linux-* packages are only partially or
+unsuccessfully installed, and let user choose, if to continue or not.
 
 Options:
     -h, -?, --help  Display this help and exit.
@@ -37,15 +42,18 @@ Options:
                     used one. Default is 1. More older kernels may be
                     kept, if they have such reverse dependencies
                     installed that are required for getting kernel
-                    updates, or if there are more than one type of
-                    kernels installed with same version number.
-    -s, --simulate  Dry-run; do not actually remove packages. You do not
+                    updates. Also, if a key linux-image package is
+                    marked "hold" by e.g. apt-mark, kernels with the
+                    respective version are not removed.
+    -s, --simulate  Dry-run; don't actually remove packages. You do not
                     have to be superuser with this option.
     -y, --yes       Purge without user confirmation.
 
 Exit Status:
     Exit with 1, if some command line argument is invalid.
-    Inherit the exit status of the apt-get purge command issued.
+    Exit with 2, if current kernel is not installed or is marked for
+    removal. Otherwise inherit the exit status of the apt-get purge
+    command issued.
 EOF
 }
 
@@ -101,22 +109,25 @@ while :; do
     shift
 done
 
-if [ $# -ne 0 ] ; then
+if [ $# -ne 0 ]; then
  show_help
  exit
 fi
 
-if ! [[ "$n" =~ ^[0-9]+$ ]] ; then
- error "$n is invalid number of older kernels to keep."
-fi
+! [[ "$n" =~ ^[0-9]+$ ]] && error "$n is invalid number of older kernels to keep." 1
 # $n is valid number
 
-Pkgs="$(dpkg-query --show --showformat='${Status} ${Package}\n' "linux-*" |
+! dpkg-query -W -f='${Status}\n' "linux-image-$(uname -r)" |
+ grep -qE "^(install|hold) ok installed" &&
+error "Current kernel is not successfully installed or it is marked for removal." 2
+# current kernel is successfully installed and wanted so
+
+Pkgs="$(dpkg-query -W -f='${Status} ${Package}\n' "linux-*" |
  awk '$2!="ok" || ($3!="installed" && $3!="not-installed") {print $4}')"
 if [ "${Pkgs}" ]; then
  echo -e "WARNING: The following linux packages are not properly\
- installed. You may want to purge or reinstall them:\n"${Pkgs} >&2
- if ! [[ "$simulate" || "$yes" ]]; then
+ installed. You may want to purge or reinstall them manually:\n"${Pkgs} >&2
+ if ! [ "$yes" ]; then
   read -r -p "Continue anyway (y/n)? " response
   response=${response,,}    # tolower
   ! [[ $response =~ ^(yes|y)$ ]] && exit
@@ -124,33 +135,65 @@ if [ "${Pkgs}" ]; then
  echo
 fi
 
-# Versions of installed kernel packages
-Versions="$(dpkg-query --show --showformat='${Status} ${Package}\n' "linux-image-*" |
-sed -nr "s/^[^ ]+ ok installed .+image-([[:digit:].]+-[^-]+)-.+/\1/p" |
-sort --version-sort --unique)"
+# Versions of installed kernel packages to decide, if remove or not
+Versions="$(dpkg-query -W -f='${Status} ${Package}\n' |
+sed -nr "s/^(install|hold) ok installed linux-image-([0-9.]+-[^-]+)-.+/\2/p" |
+sort -Vu)"
 
-#Alternative way, but maybe not as reliable, if kernel is only partially installed
-#Versions="$(ls -1U /boot/vmlinuz-* | cut -d- -f2,3 | sort -Vu)"
+# Versions of installed kernel packages marked for removal
+CandidateVersionsToPurge="$(dpkg-query -W -f='${Status} ${Package}\n' |
+sed -nr "s/^(deinstall|purge) ok installed linux-image-([0-9.]+-[^-]+)-.+/\2/p" |
+sort -Vu)"
 
-# current kernel version number (present in the respective kernel
-# package name, too)
-current="$(uname -r | cut -f1,2 -d-)"
-# List versions of kernels that have reserve dependencies
-LatestVersions="$(dpkg-query -W -f='${Package} ${Status}\n' |
- awk '/^linux-image-(generic|lowlatency|virtual)(-lts-[^ ]+|) install ok installed/{print $1}' |
- xargs dpkg-query -W -f='${Depends}\n' |
- sed -nr "s/.*linux-image-([[:digit:].]+-[^-]+)-.*/\1/p" | sort -uV)"
+VersionsToPurge=""
+if [ "${CandidateVersionsToPurge}" ]; then
+# Do not include versions that are present in ${Versions}, in case both
+# -generic and -lowlatency kenrels are installed, but only the other is
+# marked for removal.
+ VersionsToPurge="$(comm -23 <(echo -e "${CandidateVersionsToPurge}") \
+  <(echo -e "${Versions}"))"
+fi
 
-# keep n versions that are older than the current one (if they exist).
-num=$(awk '($0==c){a=NR-1-n; if(a>0){print a}else{print 0} exit}' c=${current} n=$n <<<"${Versions}")
+if [ "${Versions}" ]; then
 
-# Get the older versions to remove; never remove latest kernels though.
-VersionsToPurge="$(comm -23 <(head -n ${num} <<<"${Versions}") <(echo -e "${LatestVersions}"))"
+ # keep n versions that are older than the current one (if they exist).
+ num=$(awk '($0==c){a=NR-1-n; if(a>0){print a}else{print 0} exit}' \
+ c=$(uname -r | cut -f1,2 -d-) n=$n <<<"${Versions}")
+
+ if (("${num}" > 0)); then
+
+    # List versions of kernels that have reserve dependencies
+
+    LatestVersions="$(dpkg-query -W -f='${Package} ${Status}\n' |
+    awk '/^linux-(.+-|)image-[^0-9]+(-lts-[^ ]+|) (install|hold) ok installed/{print $1}' |
+    xargs dpkg-query -W -f='${Depends}\n' |
+    sed -nr "s/\<linux-(.+-|)image-([0-9.]+-[^-]+)-.*/\2/p" | sort -uV)"
+
+    # Get the older versions to remove; never remove latest kernels though.
+    CandidateVersionsToPurge="$(comm -23 <(head -n ${num} <<<"${Versions}") \
+     <(echo -e "${LatestVersions}"))"
+
+    if [ "${CandidateVersionsToPurge}" ] ; then
+
+        for version in ${CandidateVersionsToPurge}; do
+         if ! dpkg-query -W -f='${Status}\n' "linux-image-${version}-*" |
+          grep -q '^hold'; then
+           # purge version, if it is not marked as held by e.g. apt-get hold
+           if [ "${VersionsToPurge}" ]; then
+            VersionsToPurge+=$'\n'"${version}"
+           else
+            VersionsToPurge="${version}"
+           fi
+         fi
+        done
+    fi
+ fi
+fi
 
 if [ "${VersionsToPurge}" ]; then
     # purge linux packages matching the versions
     apt-get -q ${simulate} ${yes} purge --auto-remove $(
-    sed -r -e 's/\./\\./g' -e 's/.*/^linux-.+-&($|-)/' <<<"$VersionsToPurge")
+    sed -r -e 's/\./\\./g' -e 's/.*/^linux-.+-&($|-)/' <<<"${VersionsToPurge}")
 else
     echo "0 kernels purged."
 fi

--- a/purge-old-kernels
+++ b/purge-old-kernels
@@ -138,7 +138,7 @@ VersionsToPurge="$(head -n ${num} <<<"${Versions}")"
 
 if [ "${VersionsToPurge}" ]; then
 	# purge linux packages matching the versions
-	apt-get -q ${simulate} ${yes} purge --auto-remove $(
+	apt-get -q ${simulate} ${yes} purge $(
     sed -r -e 's/\./\\./g' -e 's/.*/^linux-.+-&($|-)/' <<<"$VersionsToPurge")
 else
 	echo "0 kernels purged."

--- a/purge-old-kernels
+++ b/purge-old-kernels
@@ -1,58 +1,145 @@
-#!/bin/sh
+#!/bin/bash
 #
-#    purge-old-kernels - remove old kernel packages
-#    Copyright (C) 2012 Dustin Kirkland <kirkland@ubuntu.com>
+#  Copyright (C) 2015       Jarno Suni (8@iki.fi)
 #
-#    Authors: Dustin Kirkland <kirkland@ubuntu.com>
-#             Kees Cook <kees@ubuntu.com>
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
 #
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, version 3 of the License.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
 #
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Ensure we're running as root
-if [ "$(id -u)" != 0 ]; then
-	echo "ERROR: This script must run as root.  Hint..." 1>&2
-	echo "  sudo $0 $@" 1>&2
-	exit 1
-fi
+set -o nounset
+set -o errexit
 
-# NOTE: This script will ALWAYS keep the currently running kernel
-# NOTE: Default is to keep 2 more, user overrides with --keep N
-KEEP=2
-# NOTE: Any unrecognized option will be passed straight through to apt-get
-APT_OPTS=
-while [ ! -z "$1" ]; do
-	case "$1" in
-		--keep)
-			# User specified the number of kernels to keep
-			KEEP="$2"
-			shift 2
-		;;
-		*)
-			APT_OPTS="$APT_OPTS $1"
-			shift 1
-		;;
-	esac
+# Usage info
+show_help() {
+cat << EOF
+Usage: ${0##*/} [OPTION]...
+Purge some kernel related packages that have older version than the
+current kernel. This is especially useful in order to prevent /boot
+partition from getting full. First warn, if some linux-* packages are
+only partially or unsuccessfully installed.
+
+Options:
+    -h, -?, --help  Display this help and exit.
+    -k NUM,
+    --keep NUM,
+    --keep=NUM	    Keep NUM kernels that are older than the currently
+                    used one. Default is 1.
+    -s, --simulate  Dry-run; don't actually remove packages. You do not
+                    have to be superuser with this option.
+    -y, --yes       Purge without user confirmation.
+
+Exit Status:
+    Exit with 1, if some command line argument is invalid.
+    Inherit the exit status of the apt-get purge command issued.
+EOF
+}
+
+error()
+{
+   echo 'ERROR: '"$1" >&2
+   exit ${2:-1}
+}
+
+n=1
+yes=""
+simulate=""
+
+while :; do
+    case ${1-} in
+        -h|-\?|--help)
+            show_help
+            exit
+            ;;
+        -k|--keep)
+			if ! ${2:+false}; then
+              n=$2
+              shift 2
+              continue
+            else
+               error 'Must specify a non-empty "--keep NUM" argument.'
+            fi
+            ;;
+        --keep=?*)
+            n=${1#*=} # Delete everything up to "=" and assign the remainder.
+            ;;
+        --keep=)
+             error 'Must specify a non-empty "--keep NUM" argument.'
+            ;;
+		-s|--simulate)
+			simulate="-s"
+			;;
+        -y|--yes)
+			yes="-y"
+			;;
+        --)              # End of all options.
+            shift
+            break
+            ;;
+        -?*)
+            echo 'WARNING: Unknown option (ignored): '"$1" >&2
+            ;;
+        # Default case: If no more options then break out of the loop.
+        *)
+            break
+    esac
+
+    shift
 done
 
-# Build our list of kernel packages to purge
-CANDIDATES=$(ls -tr /boot/vmlinuz-* | head -n -${KEEP} | grep -v "$(uname -r)$" | cut -d- -f2- | awk '{print "linux-image-" $0 " linux-headers-" $0}' )
-for c in $CANDIDATES; do
-	dpkg-query -s "$c" >/dev/null 2>&1 && PURGE="$PURGE $c"
-done
-
-if [ -z "$PURGE" ]; then
-	echo "No kernels are eligible for removal"
-	exit 0
+if [ $# -ne 0 ] ; then
+ show_help
+ exit
 fi
 
-apt-get $APT_OPTS remove --purge $PURGE
+if ! [[ "$n" =~ ^[0-9]+$ ]] ; then
+ error "$n is invalid number of older kernels to keep."
+fi
+# $n is valid number
+
+Pkgs="$(dpkg-query --show --showformat='${Status} ${Package}\n' "linux-*" |
+ awk '$2!="ok" || ($3!="installed" && $3!="not-installed") {print $4}')"
+if [ "${Pkgs}" ]; then
+ echo -e "WARNING: The following linux packages are not properly\
+ installed. You may want to purge or reinstall them:\n"${Pkgs} >&2
+ if ! [[ "$simulate" || "$yes" ]]; then
+  read -r -p "Continue anyway (y/n)? " response
+  response=${response,,}    # tolower
+  ! [[ $response =~ ^(yes|y)$ ]] && exit
+ fi
+ echo
+fi
+
+# Versions of installed kernel packages
+Versions="$(dpkg-query --show --showformat='${Status} ${Package}\n' "linux-image-*" |
+sed -nr "s/^[^ ]+ ok installed .+image-([[:digit:].]+-[^-]+)-.+/\1/p" |
+sort --version-sort --unique)"
+
+#Alternative way, but maybe not as reliable, if kernel is only partially installed
+#Versions="$(ls -1U /boot/vmlinuz-* | cut -d- -f2,3 | sort -Vu)"
+
+# current kernel version number (present in the respective kernel
+# package name, too)
+current="$(uname -r | cut -f1,2 -d-)"
+
+# keep n versions that are older than the current one (if they exist).
+num=$(awk '($0==c){a=NR-1-n; if(a>0){print a}else{print 0} exit}' c=${current} n=$n <<<"${Versions}")
+VersionsToPurge="$(head -n ${num} <<<"${Versions}")"
+
+if [ "${VersionsToPurge}" ]; then
+	# purge linux packages matching the versions
+	apt-get -q ${simulate} ${yes} purge --auto-remove $(
+    sed -r -e 's/\./\\./g' -e 's/.*/^linux-.+-&($|-)/' <<<"$VersionsToPurge")
+else
+	echo "0 kernels purged."
+fi


### PR DESCRIPTION
This is Bash script. This one purges requested amount of kernels OLDER than the current kernel, so it does not purge the newest kernel in  case system has not been rebooted after its installation. This one does not need superuser privileges, if you run it in simulate mode. This one has help option. Purges all "^linux-.*" packages corresponding the kernel versions.  Uses --auto-remove in apt-get command; maybe it is excessive?
